### PR TITLE
Release osx and windows binaries

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -64,7 +64,7 @@ jobs:
           path: dist\dgctl.exe
 
   release-all:
-    needs: [build-osx, build-windows]
+    needs: [get-version, build-osx, build-windows]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v3
@@ -81,15 +81,11 @@ jobs:
       - run: |
           zip -r dgctl-windows.zip dgctl.exe
 
-      - name: Get dgctl version
-        id: get_version
-        run: echo ::set-output name=version::$(grep version pyproject.toml | sed "s/version//g" | tr -d ' =\"')
-
       - uses: IsaacShelton/update-existing-release@v1.3.1
         with:
           token: ${{ github.token }}
           release: "latest"
-          tag: ${{ steps.get_version.outputs.version }}
+          tag: ${{ needs.get_version.outputs.version }}
           replace: true
           files: >
             dgctl-osx.zip

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -90,3 +90,4 @@ jobs:
           files: >
             dgctl-osx.zip
             dgctl-windows.zip
+

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,8 +1,8 @@
 name: Release
 on:
   push:
-    branches:
-      - "master"
+#    branches:
+#      - "master"
 
 jobs:
 
@@ -85,7 +85,7 @@ jobs:
         with:
           token: ${{ github.token }}
           release: "latest"
-          tag: ${{ needs.get_version.outputs.version }}
+          tag: "latest-release"
           replace: true
           files: >
             dgctl-osx.zip

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,8 +1,8 @@
 name: Release
 on:
   push:
-#    branches:
-#      - "master"
+    branches:
+      - "master"
 
 jobs:
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,96 @@
+name: Release
+on:
+  push:
+    branches:
+      - "master"
+
+jobs:
+
+  get-version:
+    name: Get dgctl version
+    runs-on: ubuntu-latest
+
+    outputs:
+      version: ${{ steps.get_version.outputs.version }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Get dgctl version
+        id: get_version
+        run: echo ::set-output name=version::$(grep version pyproject.toml | sed "s/version//g" | tr -d ' =\"')
+
+  build-osx:
+    needs: get-version
+    runs-on: macos-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - run: |
+          python3 -m venv .venv
+          source .venv/bin/activate
+          pip install dgctl==${{ needs.get-version.outputs.version }}
+          pip install pyinstaller
+          pyinstaller --onedir --onefile --noupx src/dgctl/dgctl.py
+          ./dist/dgctl
+
+      - name: Upload binary to artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: dgctl-osx
+          path: dist/dgctl
+
+  build-windows:
+    needs: get-version
+    runs-on: windows-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - run: |
+          python3 -m venv .venv
+          .venv\Scripts\activate
+          pip install dgctl==${{ needs.get-version.outputs.version }}
+          pip install pyinstaller
+          pyinstaller --onedir --onefile --noupx src\dgctl\dgctl.py
+          dist\dgctl
+
+      - name: Upload binary to artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: dgctl-windows
+          path: dist\dgctl.exe
+
+  release-all:
+    needs: [build-osx, build-windows]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: dgctl-osx
+
+      - run: |
+          zip -r dgctl-osx.zip dgctl
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: dgctl-windows
+
+      - run: |
+          zip -r dgctl-windows.zip dgctl.exe
+
+      - name: Get dgctl version
+        id: get_version
+        run: echo ::set-output name=version::$(grep version pyproject.toml | sed "s/version//g" | tr -d ' =\"')
+
+      - uses: IsaacShelton/update-existing-release@v1.3.1
+        with:
+          token: ${{ github.token }}
+          release: "latest"
+          tag: ${{ steps.get_version.outputs.version }}
+          replace: true
+          files: >
+            dgctl-osx.zip
+            dgctl-windows.zip

--- a/scripts/build-linux.sh
+++ b/scripts/build-linux.sh
@@ -1,0 +1,5 @@
+python3 -m venv .venv
+source .venv/bin/activate
+pip install dgctl
+pip install pyinstaller
+pyinstaller src/dgctl/dgctl.py

--- a/scripts/build-macos.sh
+++ b/scripts/build-macos.sh
@@ -1,0 +1,5 @@
+python3 -m venv .venv
+source .venv/bin/activate
+pip install dgctl
+pip install pyinstaller
+pyinstaller src/dgctl/dgctl.py

--- a/src/dgctl/dgctl.py
+++ b/src/dgctl/dgctl.py
@@ -21,3 +21,6 @@ def init(region):
 
 
 cli.add_command(init)
+
+if __name__ == "__main__":
+    cli()


### PR DESCRIPTION
This is ready for review.

This workflow will update "latest" release by uploading latest OSX and Windows binaries into the release.

Having stable url to latest release, npm can download the latest binary.